### PR TITLE
Invoquer des scripts R préexistants pour faire tourner les analyses

### DIFF
--- a/gwr_analysis.py
+++ b/gwr_analysis.py
@@ -16,7 +16,6 @@ from qgis.core import (
 import subprocess
 import os
 import tempfile
-import shutil
 
 
 class GWRAnalysisModule:

--- a/lisa_analysis.py
+++ b/lisa_analysis.py
@@ -16,7 +16,6 @@ from qgis.core import (
 import subprocess
 import os
 import tempfile
-import shutil
 
 
 class LISAAnalysisModule:

--- a/lisa_analysis.py
+++ b/lisa_analysis.py
@@ -114,240 +114,74 @@ class LISAAnalysisModule:
         del writer
         
         return True, None
-    
+
     @staticmethod
-    def write_r_script_to_file(script_path, shapefile_path, output_path, analysis_type, 
-                           variable, variable2, contiguity_type, order, 
-                           standardize_weights, significance, standardize_var):
+    def write_args(
+        shapefile_path: str,
+        output_path: str,
+        variable: str,
+        variable_2: str,
+        analysis_type: str,
+        standardize: bool,
+        contiguity_type: str,
+        order: int,
+        standardize_weights: float,
+        significance: float,
+    ) -> list[str]:
         """
-        Écrit le script R pour LISA dans un fichier
+        Écrit le script R dans un fichier
+
+        Args:
+            shapefile_path: Chemin du shapefile d'entrée
+            output_path: Chemin du shapefile de sortie
+            analysis_type: type d'analyse ("univariate", "bivariate")
+            variable: Première variable
+            variable_2: Deuxième variable
+            standardize: True pour standardiser les variables
+            contiguity_type: type de contiguïté ("queen", "rock")
+            order: ordre de la contiguïté
+            standardize_weights: True pour standardiser les poids
+            significance: valeur alpha de la p-value
         """
-    
-        # Convertir les chemins Windows en format R
+        # Convertir les chemins en format lisible par R
         shapefile_path = shapefile_path.replace("\\", "/")
         output_path = output_path.replace("\\", "/")
-    
-        # Code de standardisation
-        if standardize_var:
-            if analysis_type == "univariate":
-                standardize_code = f"""
-# Standardisation de la variable sur une COPIE
-sf_data_work <- sf_data
-sf_data_work[["{variable}"]] <- as.numeric(scale(sf_data_work[["{variable}"]]))
-"""
-            else:
-                standardize_code = f"""
-# Standardisation des variables sur une COPIE
-sf_data_work <- sf_data
-sf_data_work[["{variable}"]] <- as.numeric(scale(sf_data_work[["{variable}"]]))
-sf_data_work[["{variable2}"]] <- as.numeric(scale(sf_data_work[["{variable2}"]]))
-"""
-        else:
-            standardize_code = """
-# Pas de standardisation - créer une copie de travail
-sf_data_work <- sf_data
-"""
-    
-        # Code de vérification des variables secondaires
-        if analysis_type == "bivariate":
-            var2_check = f'''
-if (!"{variable2}" %in% names(sf_data_work)) {{
-  stop("Variable '{variable2}' non trouvée dans les données")
-}}
-'''
-            var2_na_check = f'''
-n_na_var2 <- sum(is.na(sf_data_work[["{variable2}"]]))
-if (n_na_var2 > 0) {{
-  cat(sprintf("ATTENTION: %d valeurs manquantes pour {variable2}\\n", n_na_var2))
-}}
-'''
-        else:
-            var2_check = ""
-            var2_na_check = ""
-        
-        # Code de vérification des cas complets
-        if analysis_type == "univariate":
-            complete_cases_code = f"complete_cases <- complete.cases(sf_data_work[['{variable}']])"
-        else:
-            complete_cases_code = f"complete_cases <- complete.cases(sf_data_work[['{variable}']], sf_data_work[['{variable2}']])"
-        
-        # Code d'extraction des variables
-        if analysis_type == "univariate":
-            var_extract_code = f'''
-var_data <- sf_data_work[["{variable}"]]
-cat(sprintf("Variable {variable} extraite: %d valeurs\\n", length(var_data)))
-'''
-        else:
-            var_extract_code = f'''
-var_data1 <- sf_data_work[["{variable}"]]
-var_data2 <- sf_data_work[["{variable2}"]]
-cat(sprintf("Variables {variable} et {variable2} extraites: %d valeurs chacune\\n", length(var_data1)))
-'''
-        
-        # Code de calcul LISA
-        if analysis_type == "univariate":
-            lisa_calc_code = f'''
-# LISA univarié
-cat("Analyse univariée de la variable {variable}\\n")
-lisa_result <- local_moran(weights, var_df)
-cat("Calcul LISA terminé\\n")
-'''
-        else:
-            lisa_calc_code = f'''
-# LISA bivarié
-cat("Analyse bivariée des variables {variable} et {variable2}\\n")
-lisa_result <- local_bimoran(weights, var_df$var1, var_df$var2)
-cat("Calcul LISA terminé\\n")
-'''
-        
-        script_content = f"""
-# Suppression des warnings
-options(warn = -1)
 
-# Chargement des bibliothèques
-suppressPackageStartupMessages({{
-  library(rgeoda)
-  library(sf)
-}})
+        # Créer la liste des arguments.
+        # WARN: l'ordre importe.
+        args = [
+            shapefile_path,
+            output_path,
+            variable,
+            variable_2,
+            analysis_type,
+            standardize,
+            contiguity_type,
+            order,
+            standardize_weights,
+            significance,
+        ]
+        # Convertir les bool en int
+        args = [int(x) if isinstance(x, int) else x for x in args]
+        # Convertir l'ensemble en string
+        args = [str(v) for v in args]
 
-cat("=== DEBUT DE L'ANALYSE LISA ===\\n\\n")
+        return args
 
-# Lecture des données
-cat("Lecture des données...\\n")
-sf_data <- st_read("{shapefile_path}", quiet=TRUE)
-cat(sprintf("Nombre d'entités: %d\\n", nrow(sf_data)))
-cat(sprintf("Nombre de colonnes: %d\\n", ncol(sf_data)))
 
-# Vérification de la variable
-cat("\\nVérification de la variable...\\n")
-if (!"{variable}" %in% names(sf_data)) {{
-  stop("Variable '{variable}' non trouvée dans les données")
-}}
-
-{var2_check}
-
-cat("Variable(s) présente(s)\\n")
-
-{standardize_code}
-
-# Vérification des NA
-cat("\\nVérification des valeurs manquantes...\\n")
-n_na_var1 <- sum(is.na(sf_data_work[["{variable}"]]))
-if (n_na_var1 > 0) {{
-  cat(sprintf("ATTENTION: %d valeurs manquantes pour {variable}\\n", n_na_var1))
-}}
-
-{var2_na_check}
-
-# Suppression des lignes avec NA
-{complete_cases_code}
-if (sum(!complete_cases) > 0) {{
-  cat(sprintf("Suppression de %d lignes avec valeurs manquantes\\n", sum(!complete_cases)))
-  sf_data_work <- sf_data_work[complete_cases, ]
-  sf_data <- sf_data[complete_cases, ]
-}}
-
-# Création de la matrice de poids spatiaux
-cat("\\nCréation de la matrice de poids spatiaux...\\n")
-cat(sprintf("Type de contiguïté: {contiguity_type}\\n"))
-cat(sprintf("Ordre: {order}\\n"))
-cat(sprintf("Standardisation: {str(standardize_weights).upper()}\\n"))
-
-# Créer les poids avec rgeoda
-if ("{contiguity_type}" == "queen") {{
-  weights <- queen_weights(sf_data_work, order = {order}, 
-                          include_lower_order = TRUE)
-}} else {{
-  weights <- rook_weights(sf_data_work, order = {order},
-                         include_lower_order = TRUE)
-}}
-
-cat(sprintf("Matrice de poids créée avec succès\\n"))
-
-# Préparation des données pour LISA - CRÉER UN DATA.FRAME EXPLICITE
-cat("\\nPréparation des données pour LISA...\\n")
-
-# Retirer la géométrie et créer un pur data.frame
-data_no_geom <- st_drop_geometry(sf_data_work)
-
-{var_extract_code}
-
-# Créer le data.frame pour rgeoda
-{"var_df <- data.frame(var = data_no_geom[['" + variable + "']])" if analysis_type == "univariate" 
- else "var_df <- data.frame(var1 = data_no_geom[['" + variable + "']], var2 = data_no_geom[['" + variable2 + "']])"}
-
-# Calcul LISA
-cat("\\n=== CALCUL LISA ===\\n")
-
-{lisa_calc_code}
-
-# Extraction des résultats
-cat("\\n=== EXTRACTION DES RESULTATS ===\\n")
-cat(sprintf("Seuil de significativité utilisé: {significance}\\n"))
-
-# Extraire directement avec les fonctions rgeoda
-lisa_i <- lisa_values(lisa_result)
-pvals <- lisa_pvalues(lisa_result)
-clusters <- lisa_clusters(lisa_result, cutoff = {significance})
-labels <- lisa_labels(lisa_result)
-
-cat(sprintf("Statistiques extraites pour %d observations\\n", length(lisa_i)))
-cat(sprintf("Nombre de p-values: %d\\n", length(pvals)))
-cat(sprintf("Clusters identifiés\\n"))
-
-# Préparer les résultats - COPIE PROPRE de sf_data d'origine
-result_sf <- sf_data
-
-# Ajouter les résultats LISA
-result_sf$LISA_I <- lisa_i
-result_sf$LISA_pvalue <- pvals
-result_sf$LISA_cluster <- clusters
-
-# Créer une colonne catégorielle pour les clusters
-cluster_labels <- c("Not significant", "High-High", "Low-Low", "Low-High", "High-Low", "Undefined", "Isolated")
-result_sf$LISA_category <- factor(clusters, 
-                                   levels = 0:6,
-                                   labels = cluster_labels)
-
-# Statistiques descriptives
-cat("\\n=== STATISTIQUES DESCRIPTIVES ===\\n")
-cat(sprintf("I de Moran moyen: %.4f\\n", mean(lisa_i, na.rm=TRUE)))
-cat(sprintf("I min: %.4f\\n", min(lisa_i, na.rm=TRUE)))
-cat(sprintf("I max: %.4f\\n", max(lisa_i, na.rm=TRUE)))
-
-cat("\\n=== REPARTITION DES CLUSTERS ===\\n")
-cluster_table <- table(result_sf$LISA_category)
-for (i in seq_along(cluster_table)) {{
-  cat(sprintf("%s: %d (%.1f%%)\\n", 
-              names(cluster_table)[i], 
-              cluster_table[i],
-              100 * cluster_table[i] / nrow(result_sf)))
-}}
-
-# Statistiques par type de cluster
-cat("\\n=== STATISTIQUES PAR CLUSTER ===\\n")
-for (cat_name in names(cluster_table)) {{
-  if (cluster_table[cat_name] > 0) {{
-    subset_data <- result_sf[result_sf$LISA_category == cat_name, ]
-    cat(sprintf("\\n%s:\\n", cat_name))
-    cat(sprintf("  I moyen: %.4f\\n", mean(subset_data$LISA_I, na.rm=TRUE)))
-    cat(sprintf("  p-value moyenne: %.4f\\n", mean(subset_data$LISA_pvalue, na.rm=TRUE)))
-  }}
-}}
-
-# Sauvegarde
-cat("\\nSauvegarde des résultats...\\n")
-st_write(result_sf, "{output_path}", delete_dsn=TRUE, quiet=TRUE)
-
-cat("\\n=== ANALYSE LISA TERMINEE AVEC SUCCES ===\\n")
-"""
-    
-        with open(script_path, 'w', encoding='utf-8') as f:
-            f.write(script_content)
-    
     @staticmethod
-    def run_analysis(r_path, layer, analysis_type, variable, variable2, contiguity_type, 
-                    order, standardize_weights, significance, standardize_var):
+    def run_analysis(
+        r_path,
+        layer,
+        analysis_type,
+        variable,
+        variable2,
+        contiguity_type,
+        order,
+        standardize_weights,
+        significance,
+        standardize_var,
+    ):
         """
         Exécute l'analyse LISA avec R
         
@@ -369,7 +203,9 @@ cat("\\n=== ANALYSE LISA TERMINEE AVEC SUCCES ===\\n")
         temp_dir = tempfile.mkdtemp()
         input_shp = os.path.join(temp_dir, "input.shp")
         output_shp = os.path.join(temp_dir, "output.shp")
-        script_path = os.path.join(temp_dir, "lisa_analysis.R")
+
+        # Le chemin vers le script R responsable des LISA
+        r_script = os.path.join(os.path.dirname(__file__), "r_scripts/lisa.R")
 
         try:
             # Créer un mapping sécurisé des noms de champs
@@ -403,31 +239,41 @@ cat("\\n=== ANALYSE LISA TERMINEE AVEC SUCCES ===\\n")
             )
             
             if not success:
-                return None, f"Erreur lors de l'export: {error_msg}"
+                msg = f"Erreur lors de l'export: {error_msg}"
+                return None, error_msg, temp_dir
 
             # Créer le script R
-            LISAAnalysisModule.write_r_script_to_file(
-                    script_path, input_shp, output_shp, analysis_type,
-                    variable_shp, variable2_shp, contiguity_type, order,
-                    standardize_weights, significance, standardize_var
-                )
+            cmd_args = LISAAnalysisModule.write_args(
+                input_shp,
+                output_shp,
+                variable_shp,
+                variable2_shp,
+                analysis_type,
+                standardize_var,
+                contiguity_type,
+                order,
+                standardize_weights,
+                significance,
+            )
 
             # Exécuter le script R
             result = subprocess.run(
-                [r_path, script_path],
+                [r_path, r_script] + cmd_args,
                 capture_output=True,
                 text=True,
                 timeout=600  # 10 minutes pour LISA
             )
 
             if result.returncode != 0:
-                return None, f"Erreur R :\n{result.stderr}\n\nSortie stdout:\n{result.stdout}"
+                msg = f"Erreur R :\n{result.stderr}\n\nSortie stdout:\n{result.stdout}"
+                return None, error_msg, temp_dir
 
             # Charger le résultat
             result_layer = QgsVectorLayer(output_shp, "LISA_Results", "ogr")
 
             if not result_layer.isValid():
-                return None, "Erreur lors du chargement des résultats"
+                msg = "Erreur lors du chargement des résultats"
+                return None, msg, temp_dir
 
             return result_layer, result.stdout, temp_dir
 

--- a/mgwr_analysis.py
+++ b/mgwr_analysis.py
@@ -116,257 +116,71 @@ class MGWRAnalysisModule:
         return True, None
     
     @staticmethod
-    def write_r_script_to_file(script_path, shapefile_path, output_path, dependent_var, independent_vars,
-                               kernel_name, adaptive, standardize, criterion, max_iter, tolerance):
+    def write_args(
+        input_path: str,
+        output_path: str,
+        dependent_var: str,
+        independent_vars: str,
+        kernel_name: str,
+        adaptive: bool,
+        standardize: bool,
+        bw_approach: str,
+        max_iter: int,
+        tolerance: float,
+        criterion_mgwr: str = "dCVR"
+    ) -> list[str]:
         """
-        Écrit le script R pour MGWR dans un fichier
-        Utilise GWmodel::gwr.multiscale()
-        
+        Écrit le script R dans un fichier
+
         Args:
-            script_path: Où écrire le script R
-            shapefile_path: Chemin du shapefile d'entrée
+            input_path: Chemin du shapefile d'entrée
             output_path: Chemin du shapefile de sortie
             dependent_var: Nom de la variable dépendante
             independent_vars: Liste des noms des variables indépendantes
-            kernel_name: Type de kernel ("gaussian" ou "bisquare")
+            kernel_name: Type de kernel
             adaptive: True si bande passante adaptative
             standardize: True pour standardiser les variables
-            criterion: Critère d'optimisation ("AICc", "AIC", "BIC", "CV")
+            bw_approach: Critère d'optimisation pour la bandwidth ("AIC", "CV")
             max_iter: Nombre maximal d'itérations
             tolerance: Tolérance de convergence
+            criterion_mgwr: Critère pour déterminer la convergence de la
+                            procédure de back-ftting ("CVR" or "dCVR")
         """
-        
-        # Convertir les chemins Windows en format R
-        shapefile_path = shapefile_path.replace("\\", "/")
+        # Convertir les chemins en format lisible par R
+        input_path = input_path.replace("\\", "/")
         output_path = output_path.replace("\\", "/")
-        
-        formula_vars = ' + '.join(independent_vars)
-        
-        if standardize:
-            vars_list = ', '.join([f'"{v}"' for v in [dependent_var] + independent_vars])
-            standardize_code = f"""
-# Standardisation des variables sur une COPIE
-vars_to_scale <- c({vars_list})
-sp_data_work <- sp_data
-for (var in vars_to_scale) {{
-  if (var %in% names(sp_data_work@data)) {{
-    sp_data_work@data[[var]] <- as.numeric(scale(sp_data_work@data[[var]]))
-  }}
-}}
-"""
-        else:
-            standardize_code = """
-# Pas de standardisation - créer une copie de travail
-sp_data_work <- sp_data
-"""
-        
-        # Pour gwr.multiscale : criterion = "CVR" ou "dCVR", approach = "AICc" ou "CV"
-        # On utilise CVR comme criterion et on adapte approach selon le choix utilisateur
-        if criterion == "AICc":
-            approach_gwmodel = "AICc"
-        elif criterion == "AIC":
-            approach_gwmodel = "AICc"  # Pas d'AIC seul, on utilise AICc
-        elif criterion == "CV":
-            approach_gwmodel = "CV"
-        else:
-            approach_gwmodel = "AICc"
 
-        # criterion pour gwr.multiscale dCVR utilisé par défault
-        criterion_gwmodel = "dCVR"
-        
-        script_content = f"""
-# Suppression des warnings
-options(warn = -1)
+        # Si AIC alors AICc
+        bw_approach = "AICc" if bw_approach == "AIC" else bw_approach
 
-# Chargement des bibliothèques
-suppressPackageStartupMessages({{
-  library(GWmodel)
-  library(sp)
-  library(sf)
-}})
+        # Convertir les X en string
+        independent_vars = ",".join(independent_vars)
 
-cat("=== DEBUT DE L'ANALYSE MGWR ===\\n\\n")
+        # Créer la liste des arguments.
+        # WARN: l'ordre importe.
+        args = [input_path, output_path, dependent_var, independent_vars,
+                kernel_name, adaptive, standardize, bw_approach, criterion_mgwr,
+                max_iter, tolerance]
+        # Convertir les bool en int
+        args = [int(x) if isinstance(x, int) else x for x in args]
+        # Convertir l'ensemble en string
+        args = [str(v) for v in args]
 
-# Lecture des données
-cat("Lecture des données...\\n")
-sf_data <- st_read("{shapefile_path}", quiet=TRUE)
-cat(sprintf("Nombre d'entités: %d\\n", nrow(sf_data)))
-cat(sprintf("Nombre de colonnes: %d\\n", ncol(sf_data)))
-
-# Vérification des variables
-cat("\\nVérification des variables...\\n")
-required_vars <- c("{dependent_var}", {', '.join([f'"{v}"' for v in independent_vars])})
-missing_vars <- required_vars[!required_vars %in% names(sf_data)]
-
-if (length(missing_vars) > 0) {{
-  stop(paste("Variables manquantes:", paste(missing_vars, collapse=", ")))
-}}
-
-cat("Toutes les variables sont présentes\\n")
-
-# Conversion en Spatial
-cat("\\nConversion en objet Spatial...\\n")
-sp_data <- as(sf_data, "Spatial")
-
-{standardize_code}
-
-# Vérification des NA
-cat("\\nVérification des valeurs manquantes...\\n")
-for (var in required_vars) {{
-  n_na <- sum(is.na(sp_data_work@data[[var]]))
-  if (n_na > 0) {{
-    cat(sprintf("ATTENTION: %d valeurs manquantes pour %s\\n", n_na, var))
-  }}
-}}
-
-# Suppression des lignes avec NA
-complete_cases <- complete.cases(sp_data_work@data[, required_vars])
-if (sum(!complete_cases) > 0) {{
-  cat(sprintf("Suppression de %d lignes avec valeurs manquantes\\n", sum(!complete_cases)))
-  sp_data_work <- sp_data_work[complete_cases, ]
-  sf_data <- sf_data[complete_cases, ]
-}}
-
-# Formule
-formula <- {dependent_var} ~ {formula_vars}
-cat(sprintf("\\nFormule: %s\\n", deparse(formula)))
-
-# Régression OLS globale
-cat("\\n=== REGRESSION OLS GLOBALE ===\\n")
-ols_model <- lm(formula, data=sp_data_work@data)
-print(summary(ols_model))
-
-# Calcul de la bande passante globale initiale
-cat("\\n=== CALCUL DE LA BANDE PASSANTE GLOBALE INITIALE ===\\n")
-bw_global <- bw.gwr(formula = formula,
-                    data = sp_data_work,
-                    approach = "{approach_gwmodel}",
-                    kernel = "{kernel_name}",
-                    adaptive = {str(adaptive).upper()},
-                    p = 2,
-                    longlat = FALSE)
-
-cat(sprintf("BW globale: %.2f\\n", bw_global))
-
-# Créer un vecteur de BW initiales (une par variable X + intercept)
-n_vars <- length(c({', '.join([f'"{v}"' for v in independent_vars])})) + 1  # +1 pour intercept
-bw_init <- rep(bw_global, n_vars)
-var_names <- c("Intercept", {', '.join([f'"{v}"' for v in independent_vars])})
-
-cat(sprintf("Nombre de variables (avec intercept): %d\\n", n_vars))
-
-# Calcul de la MGWR avec gwr.multiscale
-cat("\\n=== REGRESSION MGWR (gwr.multiscale) ===\\n")
-cat("Calcul en cours (peut prendre plusieurs minutes)...\\n")
-cat(sprintf("Paramètres:\\n"))
-cat(sprintf("  - Criterion: {criterion_gwmodel}\\n"))
-cat(sprintf("  - Kernel: {kernel_name}\\n"))
-cat(sprintf("  - Adaptatif: {str(adaptive).upper()}\\n"))
-cat(sprintf("  - Max itérations: {max_iter}\\n"))
-cat(sprintf("  - Tolérance: {tolerance}\\n\\n"))
-
-tryCatch({{
-  # Calculer la matrice de distances
-  cat("Calcul de la matrice de distances...\\n")
-  dMat <- gw.dist(dp.locat = coordinates(sp_data_work))
-  cat(sprintf("Matrice de distances: %d x %d\\n", nrow(dMat), ncol(dMat)))
-  
-  # Appel à gwr.multiscale
-  cat("Lancement de gwr.multiscale...\\n")
-  cat("Configuration:\\n")
-  cat(sprintf("  - Nombre de variables: %d\\n", n_vars))
-  cat(sprintf("  - Toutes les variables utilisent la même matrice de distances\\n"))
-  
-  mgwr_model <- gwr.multiscale(formula = formula,
-                                data = sp_data_work,
-                                criterion = "{criterion_gwmodel}",
-                                kernel = "{kernel_name}",
-                                adaptive = {str(adaptive).upper()},
-                                bws0 = bw_init,
-                                bw.seled = rep(TRUE, n_vars),
-                                dMats = list(dMat),
-                                predictor.centered = rep(TRUE, n_vars),
-                                var.dMat.indx = rep(1, n_vars),
-                                max.iterations = {max_iter},
-                                threshold = {tolerance},
-                                verbose = FALSE)
-  
-  cat("\\n=== RESULTATS MGWR ===\\n")
-  print(mgwr_model)
-  
-  # Extraction des résultats
-  cat("\\n=== EXTRACTION DES RESULTATS ===\\n")
-  
-  # Prédictions et résidus - COPIE PROPRE de sf_data d'origine
-  result_sf <- sf_data
-  result_sf$MGWR_yhat <- mgwr_model$SDF$yhat
-  result_sf$MGWR_residual <- mgwr_model$SDF$residual
-  result_sf$MGWR_localR2 <- mgwr_model$SDF$Local_R2
-  
-  # Coefficients locaux
-  cat("\\nExtraction des coefficients locaux...\\n")
-  coef_names <- names(mgwr_model$SDF@data)
-  coef_names <- coef_names[!coef_names %in% c("yhat", "residual", "Local_R2", "sum.w", "gwr.e")]
-  
-  for (coef_name in coef_names) {{
-    new_name <- paste0("MGWR_", coef_name)
-    result_sf[[new_name]] <- mgwr_model$SDF@data[[coef_name]]
-  }}
-  
-  # Bandes passantes optimales
-  cat("\\n=== BANDES PASSANTES OPTIMALES ===\\n")
-  if (!is.null(mgwr_model$GW.arguments$bws)) {{
-    bws <- mgwr_model$GW.arguments$bws
-    
-    # Créer un data.frame avec les BW
-    bw_df <- data.frame(
-      Variable = var_names,
-      Bandwidth = bws
-    )
-    print(bw_df)
-    
-    # Sauvegarder les bandes passantes dans le résultat
-    for (i in seq_along(var_names)) {{
-      bw_col_name <- paste0("MGWR_BW_", gsub("[^A-Za-z0-9_]", "_", var_names[i]))
-      result_sf[[bw_col_name]] <- rep(bws[i], nrow(result_sf))
-    }}
-  }}
-  
-  # Statistiques de diagnostic
-  cat("\\n=== STATISTIQUES DE DIAGNOSTIC ===\\n")
-  cat(sprintf("AIC Global OLS: %.2f\\n", AIC(ols_model)))
-  
-  if (!is.null(mgwr_model$GW.diagnostic$AICc)) {{
-    cat(sprintf("AICc MGWR: %.2f\\n", mgwr_model$GW.diagnostic$AICc))
-  }}
-  
-  cat(sprintf("R² Global OLS: %.4f\\n", summary(ols_model)$r.squared))
-  cat(sprintf("R² moyen MGWR: %.4f\\n", mean(result_sf$MGWR_localR2, na.rm=TRUE)))
-  cat(sprintf("R² médian MGWR: %.4f\\n", median(result_sf$MGWR_localR2, na.rm=TRUE)))
-  cat(sprintf("R² min MGWR: %.4f\\n", min(result_sf$MGWR_localR2, na.rm=TRUE)))
-  cat(sprintf("R² max MGWR: %.4f\\n", max(result_sf$MGWR_localR2, na.rm=TRUE)))
-  
-  # Sauvegarde
-  cat("\\nSauvegarde des résultats...\\n")
-  st_write(result_sf, "{output_path}", delete_dsn=TRUE, quiet=TRUE)
-  
-  cat("\\n=== ANALYSE MGWR TERMINEE AVEC SUCCES ===\\n")
-  
-}}, error = function(e) {{
-  cat("\\n=== ERREUR LORS DU CALCUL MGWR ===\\n")
-  cat(sprintf("Message d'erreur: %s\\n", e$message))
-  cat(sprintf("\\nTraceback:\\n"))
-  print(traceback())
-  stop(e)
-}})
-"""
-        
-        with open(script_path, 'w', encoding='utf-8') as f:
-            f.write(script_content)
+        return args
 
     @staticmethod
-    def run_analysis(r_path, layer, dependent_var, independent_vars, kernel_type,
-                    adaptive, standardize, criterion, max_iter, tolerance):
+    def run_analysis(
+        r_path,
+        layer,
+        dependent_var,
+        independent_vars,
+        kernel_type,
+        adaptive,
+        standardize,
+        criterion,
+        max_iter,
+        tolerance,
+    ):
         """
         Exécute l'analyse MGWR avec R - GWmodel::gwr.multiscale
         
@@ -388,7 +202,9 @@ tryCatch({{
         temp_dir = tempfile.mkdtemp()
         input_shp = os.path.join(temp_dir, "input.shp")
         output_shp = os.path.join(temp_dir, "output.shp")
-        script_path = os.path.join(temp_dir, "mgwr_analysis.R")
+
+        # Le chemin vers le script R responsable de la GWR
+        r_script = os.path.join(os.path.dirname(__file__), "r_scripts/mgwr.R")
 
         try:
             # Créer un mapping sécurisé des noms de champs
@@ -432,14 +248,26 @@ tryCatch({{
             kernel_name = kernel_names.get(kernel_type, "gaussian")
 
             # Créer le script R
-            MGWRAnalysisModule.write_r_script_to_file(
-                script_path, input_shp, output_shp, dependent_var_shp, independent_vars_shp,
-                kernel_name, adaptive, standardize, criterion, max_iter, tolerance
+            # MGWRAnalysisModule.write_r_script_to_file(
+                # script_path, input_shp, output_shp, dependent_var_shp, independent_vars_shp,
+                # kernel_name, adaptive, standardize, criterion, max_iter, tolerance
+            # )
+            cmd_args = MGWRAnalysisModule.write_args(
+                input_shp,
+                output_shp,
+                dependent_var_shp,
+                independent_vars_shp,
+                kernel_name,
+                adaptive,
+                standardize,
+                criterion,
+                max_iter,
+                tolerance,
             )
 
             # Exécuter le script R
             result = subprocess.run(
-                [r_path, script_path],
+                [r_path, r_script] + cmd_args,
                 capture_output=True,
                 text=True,
                 timeout=3600  # 60 minutes pour MGWR

--- a/mgwr_analysis.py
+++ b/mgwr_analysis.py
@@ -16,7 +16,6 @@ from qgis.core import (
 import subprocess
 import os
 import tempfile
-import shutil
 
 
 class MGWRAnalysisModule:

--- a/r_scripts/gwr.R
+++ b/r_scripts/gwr.R
@@ -1,0 +1,214 @@
+################################################################################
+# Script Name: gwr.R
+# Description: Fait tourner une GWR avec les paramètres fournis en entrée
+# Author: Grégoire Le Campion, Antoine Le Doeuff
+# Date created: 2025-11-26
+################################################################################
+
+# Suppression des warnings
+options(warn = -1)
+
+# Chargement des bibliothèques
+suppressPackageStartupMessages({
+  library(GWmodel)
+  library(sp)
+  library(sf)
+})
+
+# //////////////////////////////////////////////////////////////////////////////
+# Read Args --------------------------------------------------------------------
+args <- commandArgs(trailingOnly = TRUE)
+
+INPUT_PATH = args[1]
+OUTPUT_PATH = args[2]
+DEPENDENT_VAR = args[3]
+INDEPENDENT_VARS = unlist(strsplit(args[4], split = ",", fixed = TRUE))
+KERNEL = args[5]
+APPROACH = args[6]
+ADAPTATIVE = as.logical(as.integer(args[7]))
+BANDWIDTH = as.numeric(args[8])
+NEIGHBORS = as.integer(args[9])
+STANDARDIZE = as.logical(as.integer(args[10]))
+ROBUST = as.logical(as.integer(args[11]))
+
+cat("=== Résumé des paramètres fournis ===\n")
+cat("Chemin d'entrée (INPUT_PATH)        :", INPUT_PATH, "\n")
+cat("Chemin de sortie (OUTPUT_PATH)      :", OUTPUT_PATH, "\n")
+cat("Variable dépendante                 :", DEPENDENT_VAR, "\n")
+cat("Variables indépendantes             :", paste(INDEPENDENT_VARS, collapse = ", "), "\n")
+cat("Noyau choisi (KERNEL)               :", KERNEL, "\n")
+cat("Approche (APPROACH)                 :", APPROACH, "\n")
+cat("Bande passante adaptative           :", ADAPTATIVE, "\n")
+cat("Bande passante (BANDWIDTH)          :", BANDWIDTH, "\n")
+cat("Nombre de voisins (NEIGHBORS)       :", NEIGHBORS, "\n")
+cat("Standardisation (STANDARDIZE)       :", STANDARDIZE, "\n")
+cat("Méthode robuste (ROBUST)            :", ROBUST, "\n")
+cat("=====================================\n")
+
+# NOTE: La validation des paramètres est effectuée dans la méthode
+# GWRAnalysisModule.write_args()
+
+# //////////////////////////////////////////////////////////////////////////////
+# Lecture des données ----------------------------------------------------------
+cat("=== DEBUT DE L'ANALYSE GWR ===\n\n")
+
+cat("Lecture des données...\n")
+sf_data <- st_read(INPUT_PATH, quiet=TRUE)
+cat(sprintf("Nombre d'entités: %d\n", nrow(sf_data)))
+cat(sprintf("Nombre de colonnes: %d\n", ncol(sf_data)))
+
+# //////////////////////////////////////////////////////////////////////////////
+# Prétraitement ----------------------------------------------------------------
+# Vérification des variables ...................................................
+cat("\nVérification des variables...\n")
+all_vars <- c(DEPENDENT_VAR, INDEPENDENT_VARS)
+missing_vars <- all_vars[!all_vars %in% names(sf_data)]
+
+if (length(missing_vars) > 0) {
+  stop(paste("Variables manquantes:", paste(missing_vars, collapse=", ")))
+}
+
+cat("Toutes les variables sont présentes\n")
+
+# Conversion en Spatial ........................................................
+cat("\nConversion en objet Spatial...\n")
+sp_data <- as(sf_data, "Spatial")
+
+# Standardisation ..............................................................
+if (STANDARDIZE) {
+  # Standardisation des variables sur une COPIE
+  sp_data_work <- sp_data
+  for (var in all_vars) {
+    if (var %in% names(sp_data_work@data)) {
+      sp_data_work@data[[var]] <- as.numeric(scale(sp_data_work@data[[var]]))
+    }
+  }
+} else {
+  sp_data_work <- sp_data
+}
+
+# Vérification des NAs .........................................................
+cat("\nVérification des valeurs manquantes...\n")
+for (var in all_vars) {
+  n_na <- sum(is.na(sp_data_work@data[[var]]))
+  if (n_na > 0) {
+    cat(sprintf("ATTENTION: %d valeurs manquantes pour %s\n", n_na, var))
+  }
+}
+
+# Suppression des lignes avec NA
+complete_cases <- complete.cases(sp_data_work@data[, all_vars])
+if (sum(!complete_cases) > 0) {
+  cat(sprintf(
+    "Suppression de %d lignes avec valeurs manquantes\n",
+    sum(!complete_cases)
+  ))
+  sp_data_work <- sp_data_work[complete_cases, ]
+  sf_data <- sf_data[complete_cases, ]
+}
+
+# //////////////////////////////////////////////////////////////////////////////
+# Modélisation -----------------------------------------------------------------
+# Régression OLS globale .......................................................
+# Formule
+formula <-  as.formula(paste(DEPENDENT_VAR, "~", paste0(INDEPENDENT_VARS, collapse = "+")))
+cat(sprintf("\nFormule: %s\n", deparse(formula)))
+
+cat("\n=== REGRESSION OLS GLOBALE ===\n")
+ols_model <- lm(formula, data=sp_data_work@data)
+print(summary(ols_model))
+
+# Calcul de la Bandwidth .......................................................
+if (APPROACH != "None") {
+  # Calcul de la bande passante optimale
+  cat("Calcul de la bande passante optimale en cours...\n")
+  bw <- bw.gwr(
+    formula = formula,
+    data = sp_data_work,
+    approach = APPROACH,
+    kernel = KERNEL,
+    adaptive = ADAPTATIVE,
+    p = 2,
+    longlat = FALSE
+  )
+  cat(sprintf("Bande passante optimale (%s): %.4f\n", APPROACH, bw))
+} else {
+  if (ADAPTATIVE) {
+    bw <- NEIGHBORS
+  } else {
+    bw <- BANDWIDTH
+    cat(sprintf("Bande passante utilisée: %.4f\n", bw))
+  }
+}
+
+# Calcul de la GWR .............................................................
+cat("\n=== REGRESSION GWR ===\n")
+cat("Calcul en cours (peut prendre plusieurs minutes)...\n")
+
+start_time <- Sys.time()
+if (ROBUST) {
+  gwr_model <- gwr.robust(
+    formula = formula,
+    data = sp_data_work,
+    bw = bw,
+    kernel = KERNEL,
+    adaptive = ADAPTATIVE,
+    p = 2,
+    longlat = FALSE
+  )
+} else {
+  gwr_model <- gwr.basic(
+    formula = formula,
+    data = sp_data_work,
+    bw = bw,
+    kernel = KERNEL,
+    adaptive = ADAPTATIVE,
+    p = 2,
+    longlat = FALSE
+  )
+}
+end_time <- Sys.time()
+elapsed <- end_time - start_time
+cat("GWR procedure completed in", round(elapsed, 3), "seconds\n")
+
+print(gwr_model)
+
+# //////////////////////////////////////////////////////////////////////////////
+# Extraction des résultats -----------------------------------------------------
+cat("\n=== EXTRACTION DES RESULTATS ===\n")
+gwr_sdf <- gwr_model$SDF
+
+# Préparation des données de sortie - COPIE PROPRE de sf_data d'origine
+result_sf <- sf_data
+result_sf$GWR_yhat <- gwr_sdf$yhat
+result_sf$GWR_residual <- gwr_sdf$residual
+result_sf$GWR_localR2 <- gwr_sdf$Local_R2
+
+# Ajout des coefficients locaux
+coef_cols <- grep(
+  "^(?!yhat|residual|Local_R2|sum\\.w|gwr\\.e)",
+  names(gwr_sdf@data),
+  perl=TRUE,
+  value=TRUE
+)
+
+for (col in coef_cols) {
+  new_name <- paste0("GWR_", col)
+  result_sf[[new_name]] <- gwr_sdf@data[[col]]
+}
+
+# Statistiques de diagnostic
+cat("\n=== STATISTIQUES DE DIAGNOSTIC ===\n")
+cat(sprintf("AIC Global OLS: %.2f\n", AIC(ols_model)))
+cat(sprintf("AIC GWR: %.2f\n", gwr_model$GW.diagnostic$AICc))
+cat(sprintf("R² Global OLS: %.4f\n", summary(ols_model)$r.squared))
+cat(sprintf("R² moyen GWR: %.4f\n", mean(result_sf$GWR_localR2, na.rm=TRUE)))
+cat(sprintf("R² médian GWR: %.4f\n", median(result_sf$GWR_localR2, na.rm=TRUE)))
+cat(sprintf("R² min GWR: %.4f\n", min(result_sf$GWR_localR2, na.rm=TRUE)))
+cat(sprintf("R² max GWR: %.4f\n", max(result_sf$GWR_localR2, na.rm=TRUE)))
+
+# Sauvegarde
+cat("\nSauvegarde des résultats...\n")
+st_write(result_sf, OUTPUT_PATH, delete_dsn=TRUE, quiet=TRUE)
+
+cat("\n=== ANALYSE TERMINEE AVEC SUCCES ===\n")

--- a/r_scripts/gwr.R
+++ b/r_scripts/gwr.R
@@ -19,17 +19,17 @@ suppressPackageStartupMessages({
 # Read Args --------------------------------------------------------------------
 args <- commandArgs(trailingOnly = TRUE)
 
-INPUT_PATH = args[1]
-OUTPUT_PATH = args[2]
-DEPENDENT_VAR = args[3]
-INDEPENDENT_VARS = unlist(strsplit(args[4], split = ",", fixed = TRUE))
-KERNEL = args[5]
-APPROACH = args[6]
-ADAPTATIVE = as.logical(as.integer(args[7]))
-BANDWIDTH = as.numeric(args[8])
-NEIGHBORS = as.integer(args[9])
-STANDARDIZE = as.logical(as.integer(args[10]))
-ROBUST = as.logical(as.integer(args[11]))
+INPUT_PATH       <- args[1]
+OUTPUT_PATH      <- args[2]
+DEPENDENT_VAR    <- args[3]
+INDEPENDENT_VARS <- unlist(strsplit(args[4], split = ",", fixed = TRUE))
+KERNEL           <- args[5]
+APPROACH         <- args[6]
+ADAPTATIVE       <- as.logical(as.integer(args[7]))
+BANDWIDTH        <- as.numeric(args[8])
+NEIGHBORS        <- as.integer(args[9])
+STANDARDIZE      <- as.logical(as.integer(args[10]))
+ROBUST           <- as.logical(as.integer(args[11]))
 
 cat("=== Résumé des paramètres fournis ===\n")
 cat("Chemin d'entrée (INPUT_PATH)        :", INPUT_PATH, "\n")
@@ -123,13 +123,13 @@ if (APPROACH != "None") {
   # Calcul de la bande passante optimale
   cat("Calcul de la bande passante optimale en cours...\n")
   bw <- bw.gwr(
-    formula = formula,
-    data = sp_data_work,
+    formula  = formula,
+    data     = sp_data_work,
     approach = APPROACH,
-    kernel = KERNEL,
+    kernel   = KERNEL,
     adaptive = ADAPTATIVE,
-    p = 2,
-    longlat = FALSE
+    p        = 2,
+    longlat  = FALSE
   )
   cat(sprintf("Bande passante optimale (%s): %.4f\n", APPROACH, bw))
 } else {
@@ -148,23 +148,23 @@ cat("Calcul en cours (peut prendre plusieurs minutes)...\n")
 start_time <- Sys.time()
 if (ROBUST) {
   gwr_model <- gwr.robust(
-    formula = formula,
-    data = sp_data_work,
-    bw = bw,
-    kernel = KERNEL,
+    formula  = formula,
+    data     = sp_data_work,
+    bw       = bw,
+    kernel   = KERNEL,
     adaptive = ADAPTATIVE,
-    p = 2,
-    longlat = FALSE
+    p        = 2,
+    longlat  = FALSE
   )
 } else {
   gwr_model <- gwr.basic(
-    formula = formula,
-    data = sp_data_work,
-    bw = bw,
-    kernel = KERNEL,
+    formula  = formula,
+    data     = sp_data_work,
+    bw       = bw,
+    kernel   = KERNEL,
     adaptive = ADAPTATIVE,
-    p = 2,
-    longlat = FALSE
+    p        = 2,
+    longlat  = FALSE
   )
 }
 end_time <- Sys.time()

--- a/r_scripts/lisa.R
+++ b/r_scripts/lisa.R
@@ -1,0 +1,236 @@
+################################################################################
+# Script Name: lisa.R
+# Description: Fait tourner une analyse des LISA avec les paramètres
+#              fournis en entrée
+# Author: Grégoire Le Campion, Antoine Le Doeuff
+# Date created: 2025-11-28
+################################################################################
+
+# Suppression des warnings
+options(warn = -1)
+
+# Chargement des bibliothèques
+suppressPackageStartupMessages({
+  library(rgeoda)
+  library(sf)
+})
+
+# //////////////////////////////////////////////////////////////////////////////
+# Lire les arguments -----------------------------------------------------------
+args <- commandArgs(trailingOnly = TRUE)
+
+INPUT_PATH         <- args[1]
+OUTPUT_PATH        <- args[2]
+VARIABLE           <- args[3]
+VARIABLE_2         <- args[4]
+ANALYSIS_TYPE      <- args[5]
+STANDARDIZE        <- as.logical(as.integer(args[6]))
+CONTIGUITY_TYPE    <- args[7]
+ORDER              <- as.integer(args[8])
+STANDARDIZE_WEIGHT <- as.logical(as.integer(args[9]))
+SIGNIFICANCE       <- as.numeric(args[10])
+
+cat("=== Résumé des paramètres fournis ===\n")
+cat("Chemin d'entrée              :", INPUT_PATH, "\n")
+cat("Chemin de sortie             :", OUTPUT_PATH, "\n")
+cat("Variable                     :", VARIABLE, "\n")
+cat("Variable 2                   :", VARIABLE_2, "\n")
+cat("Type d'analyse               :", ANALYSIS_TYPE, "\n")
+cat("Standardisation              :", STANDARDIZE, "\n")
+cat("Type de contiguïté           :", CONTIGUITY_TYPE, "\n")
+cat("Ordre                        :", ORDER, "\n")
+cat("Poids de standardisation     :", STANDARDIZE_WEIGHT, "\n")
+cat("Alpha (p-value)              :", SIGNIFICANCE, "\n")
+cat("=====================================\n")
+
+# //////////////////////////////////////////////////////////////////////////////
+# Lecture des données ----------------------------------------------------------
+cat("=== DEBUT DE L'ANALYSE LISA ===\n\n")
+# Lecture des données
+cat("Lecture des données...\n")
+sf_data <- st_read(INPUT_PATH, quiet=TRUE)
+cat(sprintf("Nombre d'entités: %d\n", nrow(sf_data)))
+cat(sprintf("Nombre de colonnes: %d\n", ncol(sf_data)))
+
+# Vérification de la variable ..................................................
+cat("\nVérification de la variable...\n")
+if (!VARIABLE %in% names(sf_data)) {
+  stop(sprintf("Variable %s non trouvée dans les données", VARIABLE))
+}
+
+if (ANALYSIS_TYPE == "bivariate") {
+  if (!VARIABLE_2 %in% names(sf_data)) {
+    stop(sprintf("Variable %s non trouvée dans les données", VARIABLE_2))
+  }
+}
+
+cat("Variable(s) présente(s)\n")
+
+# Standardisation ..............................................................
+sf_data_work <- sf_data
+if (STANDARDIZE) {
+  sf_data_work[[VARIABLE]] <- as.numeric(scale(sf_data_work[[VARIABLE]]))
+
+  if (ANALYSIS_TYPE == "bivariate") {
+    sf_data_work[[VARIABLE]] <- as.numeric(scale(sf_data_work[[VARIABLE]]))
+    sf_data_work[[VARIABLE_2]] <- as.numeric(scale(sf_data_work[[VARIABLE_2]]))
+  }
+}
+
+# Vérification des NA ..........................................................
+cat("\nVérification des valeurs manquantes...\n")
+n_na_var1 <- sum(is.na(sf_data_work[[VARIABLE]]))
+if (n_na_var1 > 0) {
+  cat(sprintf("ATTENTION: %d valeurs manquantes pour %s\n", n_na_var1, VARIABLE))
+}
+
+if (ANALYSIS_TYPE == "bivariate") {
+  n_na_var2 <- sum(is.na(sf_data_work[[VARIABLE_2]]))
+  if (n_na_var2 > 0) {
+    cat(sprintf("ATTENTION: %d valeurs manquantes pour %s\n", n_na_var2, VARIABLE_2))
+  }
+}
+
+# Suppression des lignes avec NA
+if (ANALYSIS_TYPE == "univariate") {
+  complete_cases <- complete.cases(sf_data_work[[VARIABLE]])
+} else {
+  complete_cases <- complete.cases(
+    sf_data_work[[VARIABLE]],
+    sf_data_work[[VARIABLE_2]]
+  )
+}
+
+if (sum(!complete_cases) > 0) {
+  cat(sprintf("Suppression de %d lignes avec valeurs manquantes\n", sum(!complete_cases)))
+  sf_data_work <- sf_data_work[complete_cases, ]
+  sf_data <- sf_data[complete_cases, ]
+}
+
+# //////////////////////////////////////////////////////////////////////////////
+# Prétraitement ----------------------------------------------------------------
+# Création de la matrice de poids spatiaux .....................................
+cat("\nCréation de la matrice de poids spatiaux...\n")
+cat(sprintf("Type de contiguïté: %s\n", CONTIGUITY_TYPE))
+cat(sprintf("Ordre: %s\n", ORDER))
+cat("Standardisation des poids:", STANDARDIZE_WEIGHT,  "\n")
+
+# Créer les poids avec rgeoda
+if (CONTIGUITY_TYPE == "queen") {
+  weights <- queen_weights(sf_data_work, order = ORDER,
+                          include_lower_order = TRUE)
+} else {
+  weights <- rook_weights(sf_data_work, order = ORDER,
+                         include_lower_order = TRUE)
+}
+
+cat(sprintf("Matrice de poids créée avec succès\n"))
+
+# Préparation des données pour LISA - CRÉER UN DATA.FRAME EXPLICITE
+cat("\nPréparation des données pour LISA...\n")
+
+# Retirer la géométrie et créer un pur data.frame
+data_no_geom <- st_drop_geometry(sf_data_work)
+
+# Extraction des variables .....................................................
+if (ANALYSIS_TYPE == "univariate") {
+  var_data <- sf_data_work[[VARIABLE]]
+  cat(sprintf("Variable %s extraite: %d valeurs\n", VARIABLE, length(var_data)))
+} else {
+  var_data1 <- sf_data_work[[VARIABLE]]
+  var_data2 <- sf_data_work[[VARIABLE_2]]
+  cat(sprintf(
+    "Variables %s et %s extraites: %d valeurs chacune\n",
+    VARIABLE, VARIABLE_2, length(var_data1)
+  ))
+}
+
+# Créer le data.frame pour rgeoda
+if (ANALYSIS_TYPE == "univariate") {
+  var_df <- data.frame(var = data_no_geom[[VARIABLE]])
+} else {
+  var_df <- data.frame(
+    var1 = data_no_geom[[VARIABLE]],
+    var2 = data_no_geom[[VARIABLE_2]]
+  )
+}
+
+# Calcul LISA
+cat("\n=== CALCUL LISA ===\n")
+
+if (ANALYSIS_TYPE == "univariate") {
+  cat("Analyse univariée de la variable", VARIABLE, "\n")
+  lisa_result <- local_moran(weights, var_df)
+} else {
+  cat("Analyse bivariée des variables", VARIABLE, "et", VARIABLE_2, "\n")
+  lisa_result <- local_bimoran(weights, var_df)
+}
+cat("Calcul LISA terminé\n")
+
+# Extraction des résultats
+cat("\n=== EXTRACTION DES RESULTATS ===\n")
+cat("Seuil de significativité utilisé:", SIGNIFICANCE, "\n")
+
+# Extraire directement avec les fonctions rgeoda
+lisa_i <- lisa_values(lisa_result)
+pvals <- lisa_pvalues(lisa_result)
+clusters <- lisa_clusters(lisa_result, cutoff = SIGNIFICANCE)
+labels <- lisa_labels(lisa_result)
+
+cat(sprintf("Statistiques extraites pour %d observations\n", length(lisa_i)))
+cat(sprintf("Nombre de p-values: %d\n", length(pvals)))
+cat(sprintf("Clusters identifiés\n"))
+
+# Préparer les résultats - COPIE PROPRE de sf_data d'origine
+result_sf <- sf_data
+
+# Ajouter les résultats LISA
+result_sf$LISA_I <- lisa_i
+result_sf$LISA_pvalue <- pvals
+result_sf$LISA_cluster <- clusters
+
+# Créer une colonne catégorielle pour les clusters
+cluster_labels <- c(
+  "Not significant",
+  "High-High",
+  "Low-Low",
+  "Low-High",
+  "High-Low",
+  "Undefined",
+  "Isolated"
+)
+result_sf$LISA_category <- factor(clusters, levels = 0:6, labels = cluster_labels)
+
+# Statistiques descriptives
+cat("\n=== STATISTIQUES DESCRIPTIVES ===\n")
+cat(sprintf("I de Moran moyen: %.4f\n", mean(lisa_i, na.rm=TRUE)))
+cat(sprintf("I min: %.4f\n", min(lisa_i, na.rm=TRUE)))
+cat(sprintf("I max: %.4f\n", max(lisa_i, na.rm=TRUE)))
+
+cat("\n=== REPARTITION DES CLUSTERS ===\n")
+cluster_table <- table(result_sf$LISA_category)
+for (i in seq_along(cluster_table)) {
+  cat(sprintf(
+    "%s: %d (%.1f%%)\n",
+    names(cluster_table)[i],
+    cluster_table[i],
+    100 * cluster_table[i] / nrow(result_sf)
+  ))
+}
+
+# Statistiques par type de cluster
+cat("\n=== STATISTIQUES PAR CLUSTER ===\n")
+for (cat_name in names(cluster_table)) {
+  if (cluster_table[cat_name] > 0) {
+    subset_data <- result_sf[result_sf$LISA_category == cat_name, ]
+    cat(sprintf("\n%s:\n", cat_name))
+    cat(sprintf("  I moyen: %.4f\n", mean(subset_data$LISA_I, na.rm=TRUE)))
+    cat(sprintf("  p-value moyenne: %.4f\n", mean(subset_data$LISA_pvalue, na.rm=TRUE)))
+  }
+}
+
+# Sauvegarde
+cat("\nSauvegarde des résultats...\n")
+st_write(result_sf, OUTPUT_PATH, delete_dsn=TRUE, quiet=TRUE)
+
+cat("\n=== ANALYSE LISA TERMINEE AVEC SUCCES ===\n")

--- a/r_scripts/mgwr.R
+++ b/r_scripts/mgwr.R
@@ -1,6 +1,6 @@
 ################################################################################
 # Script Name: mgwr.R
-# Description: Fait tourner une GWR avec les paramètres fournis en entrée
+# Description: Fait tourner une MGWR avec les paramètres fournis en entrée
 # Author: Grégoire Le Campion, Antoine Le Doeuff
 # Date created: 2025-11-26
 ################################################################################

--- a/r_scripts/mgwr.R
+++ b/r_scripts/mgwr.R
@@ -1,0 +1,248 @@
+################################################################################
+# Script Name: mgwr.R
+# Description: Fait tourner une GWR avec les paramètres fournis en entrée
+# Author: Grégoire Le Campion, Antoine Le Doeuff
+# Date created: 2025-11-26
+################################################################################
+
+# Suppression des warnings
+options(warn = -1)
+
+# Chargement des bibliothèques
+suppressPackageStartupMessages({
+  library(GWmodel)
+  library(sp)
+  library(sf)
+})
+
+# //////////////////////////////////////////////////////////////////////////////
+# Read Args --------------------------------------------------------------------
+args <- commandArgs(trailingOnly = TRUE)
+
+INPUT_PATH       <- args[1]
+OUTPUT_PATH      <- args[2]
+DEPENDENT_VAR    <- args[3]
+INDEPENDENT_VARS <- unlist(strsplit(args[4], split = ",", fixed = TRUE))
+KERNEL           <- args[5]
+ADAPTATIVE       <- as.logical(as.integer(args[6]))
+STANDARDIZE      <- as.logical(as.integer(args[7]))
+BW_APPROACH      <- args[8]
+CRITERION_MGWR   <- args[9]
+MAX_ITER         <- as.integer(args[10])
+TOLERANCE        <- as.numeric(args[11])
+
+cat("=== Résumé des paramètres fournis ===\n")
+cat("Chemin d'entrée                     :", INPUT_PATH, "\n")
+cat("Chemin de sortie                    :", OUTPUT_PATH, "\n")
+cat("Variable dépendante                 :", DEPENDENT_VAR, "\n")
+cat("Variables indépendantes             :", paste(INDEPENDENT_VARS, collapse = ", "), "\n")
+cat("Noyau choisi                        :", KERNEL, "\n")
+cat("Bande passante adaptative           :", ADAPTATIVE, "\n")
+cat("Standardisation                     :", STANDARDIZE, "\n")
+cat("Approche pour la Bande Passante     :", BW_APPROACH, "\n")
+cat("Critère d'optimisation pour la MGWR :", CRITERION_MGWR, "\n")
+cat("Nombre d'itérations max             :", MAX_ITER, "\n")
+cat("Tolérance                           :", TOLERANCE, "\n")
+cat("=====================================\n")
+
+# //////////////////////////////////////////////////////////////////////////////
+# Lecture des données ----------------------------------------------------------
+cat("=== DEBUT DE L'ANALYSE MGWR ===\n\n")
+
+cat("Lecture des données...\n")
+sf_data <- st_read(INPUT_PATH, quiet=TRUE)
+cat(sprintf("Nombre d'entités: %d\n", nrow(sf_data)))
+cat(sprintf("Nombre de colonnes: %d\n", ncol(sf_data)))
+
+# //////////////////////////////////////////////////////////////////////////////
+# Prétraitement ----------------------------------------------------------------
+# Vérification des variables ...................................................
+cat("\nVérification des variables...\n")
+all_vars <- c(DEPENDENT_VAR, INDEPENDENT_VARS)
+missing_vars <- all_vars[!all_vars %in% names(sf_data)]
+
+if (length(missing_vars) > 0) {
+  stop(paste("Variables manquantes:", paste(missing_vars, collapse=", ")))
+}
+
+cat("Toutes les variables sont présentes\n")
+
+# Conversion en Spatial ........................................................
+cat("\nConversion en objet Spatial...\n")
+sp_data <- as(sf_data, "Spatial")
+
+# Standardisation ..............................................................
+if (STANDARDIZE) {
+  # Standardisation des variables sur une COPIE
+  sp_data_work <- sp_data
+  for (var in all_vars) {
+    if (var %in% names(sp_data_work@data)) {
+      sp_data_work@data[[var]] <- as.numeric(scale(sp_data_work@data[[var]]))
+    }
+  }
+} else {
+  sp_data_work <- sp_data
+}
+
+# Vérification des NAs .........................................................
+cat("\nVérification des valeurs manquantes...\n")
+for (var in all_vars) {
+  n_na <- sum(is.na(sp_data_work@data[[var]]))
+  if (n_na > 0) {
+    cat(sprintf("ATTENTION: %d valeurs manquantes pour %s\n", n_na, var))
+  }
+}
+
+# Suppression des lignes avec NA
+complete_cases <- complete.cases(sp_data_work@data[, all_vars])
+if (sum(!complete_cases) > 0) {
+  cat(sprintf(
+    "Suppression de %d lignes avec valeurs manquantes\n",
+    sum(!complete_cases)
+  ))
+  sp_data_work <- sp_data_work[complete_cases, ]
+  sf_data <- sf_data[complete_cases, ]
+}
+
+# //////////////////////////////////////////////////////////////////////////////
+# Modélisation -----------------------------------------------------------------
+# Formule
+formula <-  as.formula(paste(DEPENDENT_VAR, "~", paste0(INDEPENDENT_VARS, collapse = "+")))
+cat(sprintf("\nFormule: %s\n", deparse(formula)))
+
+# Régression OLS globale .......................................................
+cat("\n=== REGRESSION OLS GLOBALE ===\n")
+ols_model <- lm(formula, data=sp_data_work@data)
+print(summary(ols_model))
+
+# Calcul de la Bandwidth .......................................................
+cat("\n=== CALCUL DE LA BANDE PASSANTE GLOBALE INITIALE ===\n")
+bw_global <- bw.gwr(
+  formula  = formula,
+  data     = sp_data_work,
+  approach = BW_APPROACH,
+  kernel   = KERNEL,
+  adaptive = ADAPTATIVE,
+  p        = 2,
+  longlat  = FALSE
+)
+
+cat(sprintf("BW globale: %.2f\n", bw_global))
+
+# Créer un vecteur de BW initiales (une par variable X + intercept)
+n_vars <- length(INDEPENDENT_VARS) + 1
+bw_init <- rep(bw_global, n_vars)
+var_names <- c("Intercept", INDEPENDENT_VARS)
+
+cat(sprintf("Nombre de variables (avec intercept): %d\n", n_vars))
+
+# Calcul de la MGWR avec gwr.multiscale
+cat("\n=== REGRESSION MGWR (gwr.multiscale) ===\n")
+cat("Calcul en cours (peut prendre plusieurs minutes)...\n")
+cat("Paramètres:\n")
+cat("  - Criterion        : ", CRITERION_MGWR, "\n")
+cat("  - Kernel           : ", KERNEL, "\n")
+cat("  - Adaptatif        : ", ADAPTATIVE, "\n")
+cat("  - Max itérations   : ", MAX_ITER, "\n")
+cat("  - Tolérance        : ", TOLERANCE, "\n\n")
+
+tryCatch({
+  # Calculer la matrice de distances
+  cat("Calcul de la matrice de distances...\n")
+  dMat <- gw.dist(dp.locat = coordinates(sp_data_work))
+  cat(sprintf("Matrice de distances: %d x %d\n", nrow(dMat), ncol(dMat)))
+
+  # Appel à gwr.multiscale
+  cat("Lancement de gwr.multiscale...\n")
+  cat("Configuration:\n")
+  cat(sprintf("  - Nombre de variables: %d\n", n_vars))
+  cat(sprintf("  - Toutes les variables utilisent la même matrice de distances\n"))
+
+  mgwr_model <- gwr.multiscale(
+    formula            = formula,
+    data               = sp_data_work,
+    criterion          = CRITERION_MGWR,
+    kernel             = KERNEL,
+    adaptive           = ADAPTATIVE,
+    bws0               = bw_init,
+    bw.seled           = rep(TRUE, n_vars),
+    dMats              = list(dMat),
+    predictor.centered = rep(TRUE, n_vars),
+    var.dMat.indx      = rep(1, n_vars),
+    max.iterations     = MAX_ITER,
+    threshold          = TOLERANCE,
+    verbose            = FALSE
+  )
+
+  cat("\n=== RESULTATS MGWR ===\n")
+  print(mgwr_model)
+
+  # Extraction des résultats
+  cat("\n=== EXTRACTION DES RESULTATS ===\n")
+
+  # Prédictions et résidus - COPIE PROPRE de sf_data d'origine
+  result_sf <- sf_data
+  result_sf$MGWR_yhat <- mgwr_model$SDF$yhat
+  result_sf$MGWR_residual <- mgwr_model$SDF$residual
+  result_sf$MGWR_localR2 <- mgwr_model$SDF$Local_R2
+
+  # Coefficients locaux
+  # NOTE: il n'y a pas de R2 locaux comme avec gwr.basic ou gwr.robust
+  cat("\nExtraction des coefficients locaux...\n")
+  coef_names <- names(mgwr_model$SDF@data)
+  coef_names <- coef_names[!coef_names %in% c(
+    "yhat",
+    "residual",
+    "Local_R2",
+    "sum.w",
+    "gwr.e"
+  )]
+
+  for (coef_name in coef_names) {
+    new_name <- paste0("MGWR_", coef_name)
+    result_sf[[new_name]] <- mgwr_model$SDF@data[[coef_name]]
+  }
+
+  # Bandes passantes optimales
+  cat("\n=== BANDES PASSANTES OPTIMALES ===\n")
+  if (!is.null(mgwr_model$GW.arguments$bws)) {
+    bws <- mgwr_model$GW.arguments$bws
+
+    # Créer un data.frame avec les BW
+    bw_df <- data.frame(Variable = var_names, Bandwidth = bws)
+    print(bw_df)
+
+    # Sauvegarder les bandes passantes dans le résultat
+    for (i in seq_along(var_names)) {
+      bw_col_name <- paste0("MGWR_BW_", gsub("[^A-Za-z0-9_]", "_", var_names[i]))
+      result_sf[[bw_col_name]] <- rep(bws[i], nrow(result_sf))
+    }
+  }
+
+  # Statistiques de diagnostic
+  cat("\n=== STATISTIQUES DE DIAGNOSTIC ===\n")
+  cat(sprintf("AIC Global OLS: %.2f\n", AIC(ols_model)))
+
+  if (!is.null(mgwr_model$GW.diagnostic$AICc)) {
+    cat(sprintf("AICc MGWR: %.2f\n", mgwr_model$GW.diagnostic$AICc))
+  }
+
+  cat(sprintf("R² Global OLS: %.4f\n", summary(ols_model)$r.squared))
+
+  cat(sprintf("R² moyen MGWR: %.4f\n", mean(result_sf$MGWR_localR2, na.rm=TRUE)))
+  cat(sprintf("R² médian MGWR: %.4f\n", median(result_sf$MGWR_localR2, na.rm=TRUE)))
+  cat(sprintf("R² min MGWR: %.4f\n", min(result_sf$MGWR_localR2, na.rm=TRUE)))
+  cat(sprintf("R² max MGWR: %.4f\n", max(result_sf$MGWR_localR2, na.rm=TRUE)))
+
+  # Sauvegarde
+  cat("\nSauvegarde des résultats...\n")
+  st_write(result_sf, OUTPUT_PATH, delete_dsn=TRUE, quiet=TRUE)
+
+  cat("\n=== ANALYSE MGWR TERMINEE AVEC SUCCES ===\n")
+}, error = function(e) {
+  cat("\n=== ERREUR LORS DU CALCUL MGWR ===\n")
+  cat(sprintf("Message d'erreur: %s\n", e$message))
+  cat(sprintf("\nTraceback:\n"))
+  print(traceback())
+  stop(e)
+})


### PR DESCRIPTION
Cette PR répond à l'issue #4. L'objectif est de rendre le code plus lisible et maintenable par l'appel à des scripts R préexistants écrits dans le dossier `./r_scripts`.

Pour chaque classe d'analyse, la méthode `run_analysis` s'appuie dorénavant sur la nouvelle méthode `write_args()` qui écrit les arguments à passer aux scripts R. La méthode `write_r_script_to_file()` est supprimée.

**Tests :**
- [x] Windows (GWR, MGWR, LISA)
- [x] Ubuntu (GWR, MGWR, LISA)
